### PR TITLE
define Date.now() for IE8

### DIFF
--- a/timesync-client.js
+++ b/timesync-client.js
@@ -1,3 +1,6 @@
+//IE8 doesn't have Date.now()
+Date.now = Date.now || function() { return +new Date; };
+
 TimeSync = {};
 
 var offset = undefined;


### PR DESCRIPTION
Looks like IE8 doesn't have Date.now(). This should fix it. 
http://afuchs.tumblr.com/post/23550124774/date-now-in-ie8
