### PR TITLE
Added "text/plain" Mime type to fix Firefox syntax error reporting

### DIFF
--- a/timesync-server.js
+++ b/timesync-server.js
@@ -8,6 +8,7 @@ WebApp.rawConnectHandlers.use("/_timesync",
     res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
     res.setHeader("Pragma", "no-cache");
     res.setHeader("Expires", 0);
+    res.setHeader("Content-Type","text/plain");
 
     res.end(Date.now().toString());
   }


### PR DESCRIPTION
Should fix https://github.com/mizzao/meteor-timesync/issues/17
Actually it seems to be a node (not express) directive.
Since adding this, the error didn't show up.
