### PR TITLE
Adding CORS compatibility for Ionic capacitorjs

### DIFF
--- a/timesync-server.js
+++ b/timesync-server.js
@@ -18,8 +18,9 @@ WebApp.rawConnectHandlers.use("/_timesync",
     // and http://meteor.local for earlier versions
     const origin = req.headers.origin;
 
-    if (origin && ( origin === 'http://meteor.local' || 
-        origin === 'meteor://desktop' || 
+    if (origin && ( origin === 'http://meteor.local' ||
+        origin === 'capacitor://meteor.local' ||
+        origin === 'meteor://desktop' ||
         /^http:\/\/localhost:1[23]\d\d\d$/.test(origin) ) ) {
       res.setHeader('Access-Control-Allow-Origin', origin);
     }


### PR DESCRIPTION
This fix is required to use meteor time sync with capacitorjs apps on iOS.