### PR TITLE
fix: server handler not aware of app path prefix

### DIFF
--- a/timesync-server.js
+++ b/timesync-server.js
@@ -1,7 +1,9 @@
 // Use rawConnectHandlers so we get a response as quickly as possible
 // https://github.com/meteor/meteor/blob/devel/packages/webapp/webapp_server.js
 
-WebApp.rawConnectHandlers.use("/_timesync",
+const url = new URL(Meteor.absoluteUrl("/_timesync"));
+
+WebApp.rawConnectHandlers.use(url.pathname,
   function(req, res, next) {
     // Never ever cache this, otherwise weird times are shown on reload
     // http://stackoverflow.com/q/18811286/586086


### PR DESCRIPTION
HI,

This fixes configurations like:

ROOT_URL=https://www.example.com/myapp

With this change, it will listen requests at  '/myapp/_timesync'.
